### PR TITLE
fix(kno-4871): Serialize DateTimes with zero microseconds correctly

### DIFF
--- a/lib/ch/query.ex
+++ b/lib/ch/query.ex
@@ -205,9 +205,10 @@ defimpl DBConnection.Query, for: Ch.Query do
     seconds = DateTime.to_unix(dt, :second)
 
     case microsecond do
-      {val, size} when val > 0 ->
-        size = round(:math.pow(10, size))
-        Float.to_string((seconds * size + val) / size)
+      {val, precision} when precision > 0 ->
+        size = round(:math.pow(10, precision))
+        unix_seconds_float = (seconds * size + val) / size
+        :erlang.float_to_binary(unix_seconds_float, decimals: precision)
 
       _ ->
         Integer.to_string(seconds)

--- a/lib/ch/query.ex
+++ b/lib/ch/query.ex
@@ -205,7 +205,7 @@ defimpl DBConnection.Query, for: Ch.Query do
     seconds = DateTime.to_unix(dt, :second)
 
     case microsecond do
-      {val, size} when size > 0 ->
+      {val, size} when val > 0 ->
         size = round(:math.pow(10, size))
         Float.to_string((seconds * size + val) / size)
 

--- a/test/ch/connection_test.exs
+++ b/test/ch/connection_test.exs
@@ -125,13 +125,6 @@ defmodule Ch.ConnectionTest do
 
     assert Ch.query!(conn, "select {$0:DateTime('Europe/Moscow')} as d, toString(d)", [utc]).rows ==
              [[msk, "2021-01-01 15:00:00"]]
-
-    # this test case gaurds against a previous bug where DateTimes with a microsecond value of 0 and precision > 0 would
-    # get encoded as a val like "1.6095024e9" which Clickhouse would be unable to parse to a DateTime.
-    utc_with_extra_precision = ~U[2021-01-01 12:00:00.0Z]
-    naive_with_extra_precision = utc_with_extra_precision |> DateTime.shift_zone!(Ch.Test.clickhouse_tz(conn)) |> DateTime.to_naive()
-    assert Ch.query!(conn, "select {$0:DateTime} as d, toString(d)", [utc_with_extra_precision]).rows ==
-             [[~N[2021-01-01 12:00:00], to_string(naive)]]
   end
 
   test "utc datetime64 query param encoding", %{conn: conn} do
@@ -147,6 +140,13 @@ defmodule Ch.ConnectionTest do
 
     assert Ch.query!(conn, "select {$0:DateTime64(6,'Europe/Moscow')} as d, toString(d)", [utc]).rows ==
              [[msk, "2021-01-01 15:00:00.123456"]]
+
+    # this test case gaurds against a previous bug where DateTimes with a microsecond value of 0 and precision > 0 would
+    # get encoded as a val like "1.6095024e9" which Clickhouse would be unable to parse to a DateTime.
+    utc_with_zero_microsec = ~U[2021-01-01 12:00:00.000000Z]
+    naive_with_zero_microsec = utc_with_zero_microsec |> DateTime.shift_zone!(Ch.Test.clickhouse_tz(conn)) |> DateTime.to_naive()
+    assert Ch.query!(conn, "select {$0:DateTime64(6)} as d, toString(d)", [utc_with_zero_microsec]).rows ==
+             [[~N[2021-01-01 12:00:00.000000], to_string(naive_with_zero_microsec)]]
   end
 
   test "select with options", %{conn: conn} do

--- a/test/ch/connection_test.exs
+++ b/test/ch/connection_test.exs
@@ -125,6 +125,13 @@ defmodule Ch.ConnectionTest do
 
     assert Ch.query!(conn, "select {$0:DateTime('Europe/Moscow')} as d, toString(d)", [utc]).rows ==
              [[msk, "2021-01-01 15:00:00"]]
+
+    # this test case gaurds against a previous bug where DateTimes with a microsecond value of 0 and precision > 0 would
+    # get encoded as a val like "1.6095024e9" which Clickhouse would be unable to parse to a DateTime.
+    utc_with_extra_precision = ~U[2021-01-01 12:00:00.0Z]
+    naive_with_extra_precision = utc_with_extra_precision |> DateTime.shift_zone!(Ch.Test.clickhouse_tz(conn)) |> DateTime.to_naive()
+    assert Ch.query!(conn, "select {$0:DateTime} as d, toString(d)", [utc_with_extra_precision]).rows ==
+             [[~N[2021-01-01 12:00:00], to_string(naive)]]
   end
 
   test "utc datetime64 query param encoding", %{conn: conn} do


### PR DESCRIPTION
This PR addresses a bug where queries with elixir `DateTime` params that had microsecond precision with zero microseconds (e.g. `~U[2023-12-13 00:00:00.000000Z]`) would fail because the ch driver would encode them with a value like `"1.6095024e9"` which Clickhouse cannot parse.

`Float.to_string` returns the "shortest representation" possible, which in some cases will be scientific notation. [[docs]](https://hexdocs.pm/elixir/1.12.3/Float.html#to_string/1).

I discovered this because our api log "before" filter generates timestamps like this.

There are a few ways to solve this but I chose to use `:erlang.float_to_binary` to prevent the scientific notation encoding.